### PR TITLE
Integration tests failing on Windows

### DIFF
--- a/test/integration/generate-roms.js
+++ b/test/integration/generate-roms.js
@@ -13,7 +13,7 @@ async function createCmd(cmd) {
     const args = ['--assume-yes', '--skip-version-check'];
     Object.keys(cmd).forEach(key => {
         args.push('--answer');
-        args.push(key + '=' + cmd[key]);
+        args.push(key + '="' + cmd[key] + '"');
     })
 
     try { fs.mkdirSync(romDir, {recursive: true}); } catch (e) { logger.debug('Failed creating test folder, probably nothing.', e); }

--- a/test/integration/generate-roms.js
+++ b/test/integration/generate-roms.js
@@ -7,7 +7,7 @@ const fs = require('fs'),
     romDir = path.join(__dirname, 'test-roms'),
     RomCommands = require('./rom-commands'),
     spawnAndWait = require('../../util/spawn-and-wait'),
-    bin = "../../../dist/create-nes-game" + (os.platform() === 'linux' ? '-linux' : '');
+    bin = (os.platform() === "win32" ? "..\\..\\..\\dist\\create-nes-game" : "../../../dist/create-nes-game") + (os.platform() === 'linux' ? '-linux' : '');
 
 async function createCmd(cmd) {
     const args = ['--assume-yes', '--skip-version-check'];

--- a/util/spawn-and-wait.js
+++ b/util/spawn-and-wait.js
@@ -8,7 +8,7 @@ const childProcess = require('child_process'),
 function spawnAndWait(logCmd, cmd, file, args = [], options = {}) {
     logger.debug('Running: ' + path.relative(appConfiguration.workingDirectory, cmd) + ' ' + args.join(' '));
     return new Promise((resolve, reject) => {
-        const proc = childProcess.spawn(cmd, args, {cwd: options.cwd ? options.cwd : appConfiguration.workingDirectory});
+        const proc = childProcess.spawn(cmd, args, { shell: true, cwd: options.cwd ? options.cwd : appConfiguration.workingDirectory});
         const outputLogLevel = options.outputLevel ? options.outputLevel : 'debug';
         const errLogLevel = options.errOutputLevel ? options.errOutputLevel : 'warn';
 


### PR DESCRIPTION
As a result of our [discussion](https://github.com/cppchriscpp/nes-starter-kit/issues/33) in [nes-starter-kit](https://github.com/cppchriscpp/nes-starter-kit/), I was looking into why the Neslib palette initialization code wasn't being called in create-nes-game.

Before getting started on that though, I was unable to run the integration tests on a Windows system. There were a few issues that popped up that this pull request hopefully resolves:

### generate-roms.js does not wrap answer parameters in quotes, causing values with spaces to be invalid on windows.

Specifically, the parameter `--answer emulator=system default` would cause create-nes-game to throw the error: 
> [create-nes-game] [error] Failed running command Error: Cannot set field installEmulator to system! Possible values: [system default, mesen, fceux]

### Spawn command did not work on Windows
Running the Spawn command via [childProcess.spawn](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options) on Windows resulted in an error because the spawn command does not exist on Windows. I assume this works if the machine has cygwin installed or similar installed to give the machine access to Unix commands, but this [solution on Stackoverflow](Solution discovered on Stackoverflow: https://stackoverflow.com/a/51417737) offered a workaround.

> Setting the 'shell' option to true causes the spawn command to run inside of a shell and uses '/bin/sh' on Unix, and process.env.ComSpec on Windows.

There was also possibly an issue with the path to the newly built binary having forward slashes instead of backslashes on Windows, possibly caused by switching to shell execution... but as I could not run the integration tests without shell execution enabled I can't verify this.