### PR TITLE
Restoring missing neslib palette initialization code

### DIFF
--- a/generators/neslib/neslib-system-famitracker.template.asm
+++ b/generators/neslib/neslib-system-famitracker.template.asm
@@ -101,8 +101,6 @@ RLE_BYTE    =TEMP+3
 .segment "CODE"
 
 initialize_library:
-    txa
-@1:
     lda #4
     jsr _pal_bright
     jsr _pal_clear

--- a/generators/neslib/neslib-system-famitracker.template.asm
+++ b/generators/neslib/neslib-system-famitracker.template.asm
@@ -103,17 +103,6 @@ RLE_BYTE    =TEMP+3
 initialize_library:
     txa
 @1:
-    sta $000,x
-    sta $100,x
-    sta $200,x
-    sta $300,x
-    sta $400,x
-    sta $500,x
-    sta $600,x
-    sta $700,x
-    inx
-    bne @1
-
     lda #4
     jsr _pal_bright
     jsr _pal_clear

--- a/generators/neslib/neslib-system-famitracker.template.asm
+++ b/generators/neslib/neslib-system-famitracker.template.asm
@@ -101,6 +101,22 @@ RLE_BYTE    =TEMP+3
 .segment "CODE"
 
 initialize_library:
+    txa
+@1:
+    sta $000,x
+    sta $100,x
+    sta $200,x
+    sta $300,x
+    sta $400,x
+    sta $500,x
+    sta $600,x
+    sta $700,x
+    inx
+    bne @1
+
+    lda #4
+    jsr _pal_bright
+    jsr _pal_clear
     jsr _oam_clear
 
     jsr zerobss

--- a/generators/neslib/neslib-system.template.asm
+++ b/generators/neslib/neslib-system.template.asm
@@ -90,17 +90,6 @@ RLE_BYTE            =TEMP+3
 initialize_library:
     txa
 @1:
-    sta $000,x
-    sta $100,x
-    sta $200,x
-    sta $300,x
-    sta $400,x
-    sta $500,x
-    sta $600,x
-    sta $700,x
-    inx
-    bne @1
-
     lda #4
     jsr _pal_bright
     jsr _pal_clear

--- a/generators/neslib/neslib-system.template.asm
+++ b/generators/neslib/neslib-system.template.asm
@@ -88,8 +88,6 @@ RLE_BYTE            =TEMP+3
 .segment "CODE"
 
 initialize_library:
-    txa
-@1:
     lda #4
     jsr _pal_bright
     jsr _pal_clear

--- a/generators/neslib/neslib-system.template.asm
+++ b/generators/neslib/neslib-system.template.asm
@@ -88,6 +88,22 @@ RLE_BYTE            =TEMP+3
 .segment "CODE"
 
 initialize_library:
+    txa
+@1:
+    sta $000,x
+    sta $100,x
+    sta $200,x
+    sta $300,x
+    sta $400,x
+    sta $500,x
+    sta $600,x
+    sta $700,x
+    inx
+    bne @1
+
+    lda #4
+    jsr _pal_bright
+    jsr _pal_clear
     jsr _oam_clear
 
     jsr zerobss


### PR DESCRIPTION
create-nes-game's initialize_library function appears to be based on clearRAM crt0.s in neslib but is missing some initialisation code which sets a pointer to colours which is required for pal_bg() to work. This pull request attempts to restore this functionality.

A diff between [crt0.s](https://github.com/clbr/neslib/blob/master/crt0.s) and a generated neslib-system.asm:

![Screenshot of a Winmerge window highlighting code differences.](https://puu.sh/JJvjv/9e39b46d1c.png)

One thing I'm unsure of is if this change was intentional or not - a method named `clearRAM` has a more specific meaning that `initialize_library` and it's quite possible I'm missing some of the details behind this decision.